### PR TITLE
telnet_server: create new asyncio loop if none exists

### DIFF
--- a/threat9_test_bed/telnet_service/telnet_server.py
+++ b/threat9_test_bed/telnet_service/telnet_server.py
@@ -6,8 +6,11 @@ logger = logging.getLogger(__name__)
 
 class TelnetServer:
     def __init__(self, host: str, port: int, protocol):
-        self.loop = asyncio.get_event_loop()
-
+        try:
+            self.loop = asyncio.get_running_loop()
+        except RuntimeError:
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
         coro = self.loop.create_server(protocol, host, port)
         self.server = self.loop.run_until_complete(coro)
 


### PR DESCRIPTION
While building for python 3.14:
> FAILED tests/service_mocks/test_telnet_service_mock.py::test_telnet_service_mock_not_authorized - RuntimeError: There is no current event loop in thread 'MainThread'.

We're using `pytest-asyncio`@1.3.0. `asyncio` used to generate an event loop if none was found, but that was dropped in python 3.14 (this workaround was introduced in python 3.10).

The fix is to create a new event loop if none can be found. (This is backwards-compatible.)

Fixes #23